### PR TITLE
Specify layer in hostfactory for "secret control" generator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ WORKDIR /generator
 COPY Gemfile ./
 RUN gem install -g Gemfile
 
-COPY src ./src
-COPY spec ./spec
+COPY src ./src/
+COPY spec ./spec/
 COPY Rakefile VERSION ./
 
 ENTRYPOINT [ "rake" ]

--- a/docs/application.js
+++ b/docs/application.js
@@ -26776,18 +26776,20 @@ if (key == null) key = nil;if (val == null) val = nil;
         };
       }, TMP_PolicyGenerator_layer_20.$$arity = -1);
       
-      Opal.defn(self, '$host_factory', TMP_PolicyGenerator_host_factory_21 = function $$host_factory(name) {
-        var self = this;
+      Opal.defn(self, '$host_factory', TMP_PolicyGenerator_host_factory_21 = function $$host_factory(layer, name) {
+        var self = this, result = nil;
 
         if (name == null) {
           name = nil;
         }
-        return "" + "!host-factory" + ((function() {if ($truthy(name['$nil?']()['$!']())) {
-          return $rb_plus(" ", name)
+        
+        result = "!host-factory";
+        if ($truthy(name['$nil?']())) {
           } else {
-          return nil
-        }; return nil; })())
-      }, TMP_PolicyGenerator_host_factory_21.$$arity = -1);
+          result = $rb_plus(result, $rb_plus($rb_plus("\n", self.$indent("id: ")), name))
+        };
+        return (result = $rb_plus(result, $rb_plus("\n", self.$indent("" + "layer: " + (layer)))));
+      }, TMP_PolicyGenerator_host_factory_21.$$arity = -2);
       
       Opal.defn(self, '$grant', TMP_PolicyGenerator_grant_23 = function $$grant(role, $a_rest) {
         var TMP_renderMembers_22, self = this, members, result = nil;
@@ -27025,7 +27027,7 @@ if (index == null) index = nil;
             Opal.def(self, '$render_hosts', TMP_render_hosts_47 = function $$render_hosts(groups) {
               var TMP_46, self = this;
 
-              return [self.$blank_line(), self.$comment("=== Layer for Automated Secret Access ==="), self.$policy("hosts", self.$layer(), self.$host_factory(), $hash2(["description"], {"description": "Layer & Host Factory for machines that can read secrets"})), $send(groups, 'map', [], (TMP_46 = function(group){var self = TMP_46.$$s || this;
+              return [self.$blank_line(), self.$comment("=== Layer for Automated Secret Access ==="), self.$policy("hosts", self.$layer(), self.$host_factory(self.$layer()), $hash2(["description"], {"description": "Layer & Host Factory for machines that can read secrets"})), $send(groups, 'map', [], (TMP_46 = function(group){var self = TMP_46.$$s || this;
 if (group == null) group = nil;
               return self.$grant(self.$group("" + (group) + "/secrets-users"), self.$layer("hosts"))}, TMP_46.$$s = self, TMP_46.$$arity = 1, TMP_46))].$flatten()
             }, TMP_render_hosts_47.$$arity = 1);

--- a/src/generator.md
+++ b/src/generator.md
@@ -148,8 +148,10 @@ def layer name=nil, **annotations
   result += "\n" + indent(render_annotations annotations) unless annotations.empty?
 end
 
-def host_factory name=nil
-  "!host-factory#{' ' + name if not name.nil?}"
+def host_factory layer, name=nil
+  result = "!host-factory"
+  result += "\n" + indent('id: ') + name unless name.nil?
+  result += "\n" + indent("layer: #{layer}")
 end
 
 def grant role, *members
@@ -322,7 +324,7 @@ def toMAML
     [
       blank_line,
       comment('=== Layer for Automated Secret Access ==='),
-      policy('hosts', layer, host_factory,
+      policy('hosts', layer, host_factory(layer),
              description: 'Layer & Host Factory for machines that can read secrets'),
       groups.map { |group|
         grant(group("#{group}/secrets-users"),

--- a/tests.md
+++ b/tests.md
@@ -381,6 +381,7 @@ end
       body:
         - !layer
         - !host-factory
+          layer: !layer
     - !grant
       role: !group alfa/secrets-users
       member: !layer hosts


### PR DESCRIPTION
Closes #9 

#### What does this PR do?
It updates the "secret control" generator.
Currently, it specifies a host factory with no layer. This is an error. Now the hostfactory helper is updated so that it requires a layer as an argument, and the generator makes use of this.